### PR TITLE
Improved pcfg error

### DIFF
--- a/fastcaddy/core.py
+++ b/fastcaddy/core.py
@@ -72,7 +72,7 @@ def pcfg(d, path='/', method='post'):
     response = f(get_path(path), json=obj2dict(d))
     try: response.raise_for_status()
     except Exception as e:
-        e.add_note(f'{response.status_code=} {json.loads(response.text)}')
+        e.add_note(f"Error: '{json.loads(response.text)['error']}'")
         raise
     return response.text or None
 

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -216,7 +216,7 @@
     "    response = f(get_path(path), json=obj2dict(d))\n",
     "    try: response.raise_for_status()\n",
     "    except Exception as e:\n",
-    "        e.add_note(f'{response.status_code=} {json.loads(response.text)}')\n",
+    "        e.add_note(f\"Error: '{json.loads(response.text)['error']}'\")\n",
     "        raise\n",
     "    return response.text or None"
    ]


### PR DESCRIPTION
Helps make it easier to determine where a CFG change went wrong. Aids in debugging and adding features to fastcaddy-powered applications.

The current error response tells us there's an error, but does not tell us what the error is:

```python
HTTPStatusError                           Traceback (most recent call last)
Cell In[2], line 1
----> 1 pcfg({'blarg': 'asdf'})

File ~/git/fastcaddy/fastcaddy/core.py:73, in pcfg(d, path, method)
     71 f = getattr(httpx, method)
     72 response = f(get_path(path), json=obj2dict(d))
---> 73 response.raise_for_status()
     74 return response.text or None

File ~/.venv/lib/python3.12/site-packages/httpx/_models.py:829, in Response.raise_for_status(self)
    827 error_type = error_types.get(status_class, "Invalid status code")
    828 message = message.format(self, error_type=error_type)
--> 829 raise HTTPStatusError(message, request=request, response=self)

HTTPStatusError: Server error '500 Internal Server Error' for url 'http://localhost:2019/config/'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
```

This PR changes the error response to this, where the last line informs the user of what the error is:

```python
---------------------------------------------------------------------------
HTTPStatusError                           Traceback (most recent call last)
Cell In[2], line 1
----> 1 pcfg({'blarg': 'asdf'})

File ~/git/fastcaddy/fastcaddy/core.py:73, in pcfg(d, path, method)
     71 f = getattr(httpx, method)
     72 response = f(get_path(path), json=obj2dict(d))
---> 73 try: response.raise_for_status()
     74 except Exception as e:
     75     e.add_note(f'{response.status_code=} {json.loads(response.text)}')

File ~/.venv/lib/python3.12/site-packages/httpx/_models.py:829, in Response.raise_for_status(self)
    827 error_type = error_types.get(status_class, "Invalid status code")
    828 message = message.format(self, error_type=error_type)
--> 829 raise HTTPStatusError(message, request=request, response=self)

HTTPStatusError: Server error '500 Internal Server Error' for url 'http://localhost:2019/config/'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
Error: 'loading new config: json: unknown field "blarg"'
```
