### PR TITLE
update acme_path var name

### DIFF
--- a/fastcaddy/core.py
+++ b/fastcaddy/core.py
@@ -127,7 +127,7 @@ def add_acme_config(cf_token):
     pcfg({})
     init_path(automation_path)
     val = [get_acme_config(cf_token)]
-    pcfg([{'issuers':val}], acme_path+'/policies')
+    pcfg([{'issuers':val}], automation_path+'/policies')
 
 # %% ../nbs/00_core.ipynb 34
 srvs_path = '/apps/http/servers'

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -412,7 +412,7 @@
     "    pcfg({})\n",
     "    init_path(automation_path)\n",
     "    val = [get_acme_config(cf_token)]\n",
-    "    pcfg([{'issuers':val}], acme_path+'/policies')"
+    "    pcfg([{'issuers':val}], automation_path+'/policies')"
    ]
   },
   {


### PR DESCRIPTION
commit bb8d437 changes var name `acme_path` to `automation_path`.
However, I noticed the old var name was still used in one function. This PR also updates that one to the new name.

(I ran into this issue when using `acme_path` outside of fastcaddy and noticed the var name was missing.)